### PR TITLE
No delimiter

### DIFF
--- a/plugin/codepainter.vim
+++ b/plugin/codepainter.vim
@@ -38,50 +38,76 @@ function! s:ValidateColorIndex(input)
   return l:n
 endfunction
 
+func! s:SameLineMark(start_pos, end_pos, delta_pos)
+ "calc n of bytes on the same line
+    let l:mark = nvim_buf_add_highlight(0, 0, g:paint_name,
+                \ a:start_pos[1] - 1,
+                \ a:start_pos[2] - 1,
+                \ a:start_pos[2] + a:delta_pos[1])
+    let g:marks[a:start_pos[1]] =
+                \ [a:start_pos, a:end_pos, l:mark, g:paint_name]
+endfunc
+
+func! s:VisModeMark(start_pos, end_pos, delta_pos)
+    let aux_start_pos = copy(a:start_pos)
+    let aux_end_pos = copy(a:start_pos)
+    let line = 0
+    while line < a:delta_pos[0]
+        let aux_start_pos[1] += line
+        let aux_end_pos[1] += line
+        let aux_end_pos[2] = 2147483647 "little hack to say all the line
+        let l:mark = nvim_buf_add_highlight(0, 0, g:paint_name,
+                    \ a:start_pos[1] - 1 + line,
+                    \ a:start_pos[2] - 1, -1)
+        let g:marks[a:start_pos[1] + line] =
+                \  [copy(aux_start_pos), copy(aux_end_pos), l:mark, g:paint_name]
+        let line += 1
+    endwhile
+    let aux_start_pos[1] += 1
+    let l:mark = nvim_buf_add_highlight(0, 0, g:paint_name,
+    \ a:start_pos[1] + line - 1, 0,
+    \ a:start_pos[2] + a:delta_pos[1])
+    let g:marks[a:start_pos[1] + line] =
+            \  [aux_start_pos, a:end_pos, l:mark, g:paint_name]
+endfunc
+
+func! s:BlockVisModeMark(start_pos, end_pos, delta_pos)
+    let line = 0
+    let aux_start_pos = copy(a:start_pos)
+    let aux_end_pos = copy(a:start_pos)
+    while line < a:delta_pos[0]
+        let aux_start_pos[1] += line
+        let aux_end_pos[1] += line
+        let aux_end_pos[2] = a:end_pos[2]
+        let l:mark = nvim_buf_add_highlight(0, 0, g:paint_name,
+                    \ a:start_pos[1] + line - 1,
+                    \ a:start_pos[2] - 1,
+                    \ a:start_pos[2] +  a:delta_pos[1])
+        let g:marks[a:start_pos[1] + line] =
+                    \  [copy(aux_start_pos), copy(aux_end_pos), l:mark, g:paint_name]
+        let line += 1
+    endwhile
+    let aux_start_pos[1] += 1
+    let aux_end_pos[1] += 1
+    let l:mark = nvim_buf_add_highlight(0, 0, g:paint_name,
+                    \ a:start_pos[1] + line - 1,
+                    \ a:start_pos[2] - 1,
+                    \ a:start_pos[2] +  a:delta_pos[1])
+   let g:marks[a:start_pos[1] + line] =
+                    \  [aux_start_pos, aux_end_pos, l:mark, g:paint_name]
+endfunc
+
 
 func! s:MarkSelection(start_pos, end_pos, v_mode)
-    let l:delta_pos = [a:end_pos[1] - a:start_pos[1], a:end_pos[2] - a:start_pos[2]]
-    let l:mark = 0
-    "on the same line
-    if l:delta_pos[0] == 0
-        "calc n of bytes on the same line
-        let l:mark = nvim_buf_add_highlight(0, 0, g:paint_name,
-                    \ a:start_pos[1] - 1,
-                    \ a:start_pos[2] - 1,
-                    \ a:start_pos[2] + l:delta_pos[1])
-        let g:marks[a:start_pos[1]] =
-                    \ [a:start_pos, a:end_pos, l:mark, g:paint_name]
+    let l:delta_pos = [ a:end_pos[1] - a:start_pos[1],
+                    \   a:end_pos[2] - a:start_pos[2]]
+    if l:delta_pos[0] == 0 "on the same line
+        call s:SameLineMark(a:start_pos, a:end_pos, l:delta_pos)
     else "more than 1 line
         if a:v_mode == 'v' "visual mode
-            let line = 0
-            while line < l:delta_pos[0]
-                let aux_pos = copy(a:start_pos)
-                let aux_pos[2] = 2147483647 "little hack to say all the line
-                let l:mark = nvim_buf_add_highlight(0, 0, g:paint_name,
-                            \ a:start_pos[1] - 1 + line,
-                            \ a:start_pos[2] - 1, -1)
-                let g:marks[a:start_pos[1] + line] =
-                        \  [a:start_pos, aux_pos, l:mark, g:paint_name]
-                let line += 1
-            endwhile
-            let l:mark = nvim_buf_add_highlight(0, 0, g:paint_name,
-            \ a:start_pos[1] + line - 1, 0,
-            \ a:start_pos[2] + l:delta_pos[1])
-            let g:marks[a:start_pos[1] + line] =
-                    \  [a:start_pos, a:end_pos, l:mark, g:paint_name]
+            call s:VisModeMark(a:start_pos, a:end_pos, l:delta_pos)
         else "block visual mode
-            let line = 0
-            while line <= l:delta_pos[0]
-                let aux_pos = copy(a:start_pos)
-                let aux_pos[2] = 2147483647
-                let l:mark = nvim_buf_add_highlight(0, 0, g:paint_name,
-                \ a:start_pos[1]+ line-1,
-                \ a:start_pos[2] - 1,
-                \ a:start_pos[2] +  l:delta_pos[1])
-                let g:marks[a:start_pos[1] + line] =
-                        \  [a:start_pos, aux_pos, l:mark, g:paint_name]
-                let line += 1
-            endwhile
+            call s:BlockVisModeMark(a:start_pos, a:end_pos, l:delta_pos)
         endif
     endif
 endfunc
@@ -94,27 +120,31 @@ func! codepainter#paintText(v_mode) range
     if getline("'>")[col("'>") - 1] == "0x0a"
         let l:end_pos[2] -= 1
     endif
-    "if it wasn't stored, we mark it
-    if !has_key(g:marks, l:start_pos[1])
-        call s:MarkSelection(l:start_pos, l:end_pos, a:v_mode)
-        return
-    endif
-    let l:known_mark = g:marks[l:start_pos[1]]
-    let l:col_deltas = [l:start_pos[2] - l:known_mark[0][2],
-                \       l:end_pos[2] - l:known_mark[1][2]]
-    "inside the known mark -> unmark
-    if (l:col_deltas[0] >= 0 && l:col_deltas[1] <= 0)
-        call nvim_buf_clear_namespace(0, l:known_mark[2], l:start_pos[1]-1,-1)
-        unlet g:marks[l:start_pos[1]]
-        if(l:known_mark[3] != g:paint_name)
+    let index = 0
+    while index <= l:end_pos[1] - l:start_pos[1]
+        "if it wasn't stored, we mark it
+        if !has_key(g:marks, l:start_pos[1] + index)
             call s:MarkSelection(l:start_pos, l:end_pos, a:v_mode)
+            return
         endif
-    elseif (l:col_deltas[0] >= 0 && l:col_deltas[1] > 0) "extending mark
-        call nvim_buf_clear_namespace(0, l:known_mark[2], l:start_pos[1]-1,-1)
-        call s:MarkSelection(l:start_pos, l:end_pos, a:v_mode)
-    elseif (l:col_deltas[0] < 0 && l:col_deltas[1] >= 0)
-        call nvim_buf_clear_namespace(0, l:known_mark[2], l:start_pos[1]-1,-1)
-    endif
+        let l:known_mark = g:marks[l:start_pos[1] + index]
+        let l:col_deltas = [l:start_pos[2] - l:known_mark[0][2],
+                    \       l:end_pos[2] - l:known_mark[1][2]]
+        "inside the known mark -> unmark
+        if (l:col_deltas[0] >= 0 && l:col_deltas[1] <= 0)
+            call nvim_buf_clear_namespace(0, l:known_mark[2], l:start_pos[1]+index-1,-1)
+            unlet g:marks[l:start_pos[1]+index]
+            if(l:known_mark[3] != g:paint_name)
+                call s:MarkSelection(l:start_pos, l:end_pos, a:v_mode)
+            endif
+        elseif (l:col_deltas[0] >= 0 && l:col_deltas[1] > 0) "extending mark
+            call nvim_buf_clear_namespace(0, l:known_mark[2], l:start_pos[1]+index-1,-1)
+            call s:MarkSelection(l:start_pos, l:end_pos, a:v_mode)
+        elseif (l:col_deltas[0] < 0 && l:col_deltas[1] >= 0)
+            call nvim_buf_clear_namespace(0, l:known_mark[2], l:start_pos[1]+index-1,-1)
+        endif
+        let index += 1
+    endwhile
 endfunc
 
 vnoremap <F2> :<c-u>call codepainter#paintText(visualmode())<cr>
@@ -149,3 +179,6 @@ func! codepainter#ChangeColorByName(strPaint)
     let g:paint_name = substitute(a:strPaint, "\"", "" ,"g")
 endfunc
 
+func! codepainter#SaveMarks()
+    silent! call writefile(split(g:marks, "\n", 1), glob('/marks.json'), 'b')
+endfunc

--- a/plugin/codepainter.vim
+++ b/plugin/codepainter.vim
@@ -70,9 +70,6 @@ endfunc
 
 func! codepainter#paintText(v_mode) range
     let [start_pos, delta_pos] = s:GrabSelectionValues()
-    echom "mode $" . a:v_mode . "$"
-    echom start_pos
-    echom delta_pos
     "mark text
     call s:MarkSelection(start_pos, delta_pos, a:v_mode)
 endfunc

--- a/plugin/codepainter.vim
+++ b/plugin/codepainter.vim
@@ -18,6 +18,7 @@ hi paint9 gui=reverse guifg=#C2B330 guibg=#2E3440
 
 let g:paint_indexes = [0,0,0,0,0,0,0,0,0,0]
 let g:paint_n = 0
+let g:layer0 = nvim_create_namespace("layer0")
 
 function! s:ValidateColorIndex(input)
   let l:n = str2nr(a:input)
@@ -45,23 +46,26 @@ func! s:MarkSelection(start_pos, delta_pos, v_mode)
     let l:paint_name = "paint" . g:paint_n
     if a:delta_pos[0] == 0
         "calc n of bytes on the same line
-        call matchaddpos(l:paint_name, [[a:start_pos[1], a:start_pos[2], a:delta_pos[1] + 1]])
+        call nvim_buf_add_highlight(0, g:layer0, l:paint_name,
+                    \ a:start_pos[1] - 1,
+                    \ a:start_pos[2] - 1, a:start_pos[2] + a:delta_pos[1])
     else
         "more than 1 line
         if a:v_mode == 'v' "visual mode
             let line = 0
             while line < a:delta_pos[0]
-                call matchaddpos(l:paint_name, [a:start_pos[1] + line])
+                call nvim_buf_add_highlight(0, g:layer0, l:paint_name,
+                            \ a:start_pos[1] - 1 + line,
+                            \ a:start_pos[2] - 1, -1)
                 let line += 1
             endwhile
-            call matchaddpos(l:paint_name,
-            \ [[a:start_pos[1] + line, 1, a:start_pos[2] + a:delta_pos[1] ]])
-
+            call nvim_buf_add_highlight(0, g:layer0, l:paint_name,
+            \ a:start_pos[1]+line - 1, 0, a:start_pos[2] + a:delta_pos[1])
         else "block visual mode
             let line = 0
             while line <= a:delta_pos[0]
-                call matchaddpos(l:paint_name,
-                \ [[a:start_pos[1] + line, a:start_pos[2], a:delta_pos[1] + 1 ]])
+                call nvim_buf_add_highlight(0, g:layer0, l:paint_name,
+                \ a:start_pos[1]+ line-1, a:start_pos[2] - 1, a:start_pos[2] +  a:delta_pos[1])
                 let line += 1
             endwhile
         endif

--- a/plugin/codepainter.vim
+++ b/plugin/codepainter.vim
@@ -143,7 +143,7 @@ func! codepainter#ChangeColor(nPaint)
 endfunc
 
 func! codepainter#ChangeColorByName(strPaint)
-    if a:strPaint != type(1)
+    if a:strPaint != type(1) || empty(a:strPaint)
         return
     endif
     let g:paint_name = substitute(a:strPaint, "\"", "" ,"g")


### PR DESCRIPTION
**Features**

+ Removing delimiters taking advantage of neovim's neovim_buf_add_highlight properties (which "follows" the text)

- Breaking compatibility with vim. Won't merge until fix it. Vim should use text properties (Thanks @rcreasi for the advice on this).