### PR TITLE
implement optional default mappings

### DIFF
--- a/autoload/codepainter/config.vim
+++ b/autoload/codepainter/config.vim
@@ -1,0 +1,9 @@
+let s:cpo_save = &cpo
+set cpo&vim
+
+func! codepainter#config#DefaultMappings() abort
+  return get(g:, 'codepainter_default_mappings', 1)
+endfunc
+
+let &cpo = s:cpo_save
+unlet! s:cpo_save

--- a/plugin/codepainter.vim
+++ b/plugin/codepainter.vim
@@ -5,8 +5,10 @@ if exists("g:loaded_painter")
 endif
 let g:loaded_painter = 1
 
-vnoremap <F2> :<c-u>call codepainter#paintText(visualmode())<cr>
-nnoremap <F2> :<c-u>call codepainter#paintText('')<cr>
+if codepainter#config#DefaultMappings()
+  vnoremap <F2> :<c-u>call codepainter#paintText(visualmode())<cr>
+  nnoremap <F2> :<c-u>call codepainter#paintText('')<cr>
+endif
 
 command! -nargs=1 PainterPickColor call codepainter#ChangeColor(<f-args>)
 command! -nargs=1 PainterPickColorByName call codepainter#ChangeColorByName(<f-args>)


### PR DESCRIPTION
`let g:codepainter_default_mappings = 0` to disable default mappings. Default mappings are enabled by default.