### PR TITLE
Wrong pick color cmd. See plugin/codepainter.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you had something already painted, selecting and applying the same color will
 
 ### Changing between colors
 
-There are 10 colors pre-defined on the plugin source (named "paint<n>"). You can use any highlight group you want using `:PainterChangeColor <number>` for the default ones or `:PainterChangeColorByName <name>` to supply your own highlight group. The default group is "paint0".
+There are 10 colors pre-defined on the plugin source (named "paint<n>"). You can use any highlight group you want using `:PainterPickColor <number>` for the default ones or `:PainterPickColorByName <name>` to supply your own highlight group. The default group is "paint0".
 
 ### Cleaning everything
 


### PR DESCRIPTION
Based on (plugin/codepainter.vim): command! -nargs=1 PainterPickColor          silent! call codepainter#ChangeColor(<f-args>)
Either:
    :PainterPickColor <number>
Or
    :call codepainter#ChangeColor(<number>)
Analogous for PainterPickColorByName