### PR TITLE
fix(Save-/LoadMarks): add opt to keep original file-ext

### DIFF
--- a/autoload/codepainter.vim
+++ b/autoload/codepainter.vim
@@ -21,6 +21,7 @@ let g:marks = {}
 let g:vim_index = 0
 let g:navigation_index = 0
 let g:has_nvim = has('nvim')
+let g:codepainter_file_keep_original_extension = 1
 
 "dictionary holding the markings folowing this structure
 "marks = {
@@ -221,7 +222,26 @@ func! codepainter#SaveMarks(...) abort
         " If no extension add .json
         let l:path = l:path . ".json"
     else
-        let l:path = substitute(l:path, expand("%:e"), "json", "")
+        if l:aux ==# 'json'
+            " Path already ends with .json
+            " Potential overwrite if script with marks is also a JSON
+            " Opt. A: echo error and return
+            if a:0 == 0
+                echom "Current script is JSON"
+                echom "Pass an arg to PainterSaveMarks to store the codepainters"
+                return
+            endif
+            " Opt. B: replace all next '.json' with '_codepainter.json'
+            " (not coded)
+        else
+            if g:codepainter_file_keep_original_extension
+                " Add .json to path keeping original extension
+                let l:path = expand('%:p') . '.json'
+            else
+                " Replace extension with .json
+                let l:path = expand('%:p:r') . '.json'
+            endif
+        endif
     endif
     let jsonString = json_encode(g:marks)
     execute ("redir! >" . l:path)
@@ -238,7 +258,13 @@ func! codepainter#LoadMarks(...) abort
             " If no extension add .json
             let l:path = l:path . ".json"
         else
-            let l:path = substitute(l:path, expand("%:e"), "json", "")
+            if g:codepainter_file_keep_original_extension
+                " Add .json to path keeping original extension
+                let l:path = expand('%:p') . '.json'
+            else
+                " Replace extension with .json
+                let l:path = expand('%:p:r') . '.json'
+            endif
         endif
     endif
     let l:file = readfile(l:path)

--- a/autoload/codepainter.vim
+++ b/autoload/codepainter.vim
@@ -216,7 +216,7 @@ endfunc
 
 func! codepainter#SaveMarks(...) abort
     let l:path = a:0 == 0 ? expand("%") : substitute(a:1, "\"", "","g")
-    let l:aux = expand("%:e")
+    let l:aux = fnamemodify(expand(l:path), ':e')
     if len(l:aux) == 0
         let l:path = l:path . ".json"
     else
@@ -232,7 +232,7 @@ endfunc
 func! codepainter#LoadMarks(...) abort
     let l:path = a:0 == 0 ? expand("%") : substitute(a:1, "\"", "","g")
     if a:0 == 0
-        let l:aux = expand("%:e")
+        let l:aux = fnamemodify(expand(l:path), ':e')
         if len(l:aux) == 0
             let l:path = l:path . ".json"
         else

--- a/autoload/codepainter.vim
+++ b/autoload/codepainter.vim
@@ -218,6 +218,7 @@ func! codepainter#SaveMarks(...) abort
     let l:path = a:0 == 0 ? expand("%") : substitute(a:1, "\"", "","g")
     let l:aux = fnamemodify(expand(l:path), ':e')
     if len(l:aux) == 0
+        " If no extension add .json
         let l:path = l:path . ".json"
     else
         let l:path = substitute(l:path, expand("%:e"), "json", "")
@@ -234,6 +235,7 @@ func! codepainter#LoadMarks(...) abort
     if a:0 == 0
         let l:aux = fnamemodify(expand(l:path), ':e')
         if len(l:aux) == 0
+            " If no extension add .json
             let l:path = l:path . ".json"
         else
             let l:path = substitute(l:path, expand("%:e"), "json", "")

--- a/plugin/codepainter.vim
+++ b/plugin/codepainter.vim
@@ -15,5 +15,5 @@ command! -nargs=1 PainterPickColor          silent! call codepainter#ChangeColor
 command! -nargs=1 PainterPickColorByName    silent! call codepainter#ChangeColorByName(<f-args>)
 command! -nargs=0 PainterEraseAll           silent! call codepainter#EraseAll()
 command! -nargs=? PainterEraseLine          silent! call codepainter#EraseLine(<f-args>)
-command! -nargs=? PainterSaveMarks          silent! call codepainter#SaveMarks(<f-args>)
+command! -nargs=? PainterSaveMarks          call codepainter#SaveMarks(<f-args>)
 command! -nargs=? PainterLoadMarks          silent! call codepainter#LoadMarks(<f-args>)


### PR DESCRIPTION
- [x] Previous `let l:path = substitute(l:path, expand("%:e"), "json", "")` did replace first extension match. E.g. `filepy.py` would be `filejson.py`
- [x] If I have multiple files with same filename (without extension), like `main.js` and `main.html`, then now with `let g:codepainter_file_keep_original_extension = 1` I can have 2 different codepainter JSONs (`main.js.json` and `main.html.json`). Or if set to `0` just `main.json` as previous to this PR
- [x] Previous potential overwrite if script with marks is also a JSON. Now `codepainter#SaveMarks()` echoes a warning, thus `silent` removed from `PainterSaveMarks` declaration to see those error-msgs

Next is an example of what now can be achieved. TLDR: create JSON files for auto-save/load codepainter-marks with a regex that matches `.gitignore`. Example of how to use:
1. `vim filepy.py`
2. [Create a codepainter mark]
3. `:call SaveCodePaintersToJSON()` creates `filepy.py__noGit_vim-codePainters.json`. Which is awesome since `py` of `filepy`is not renamed by `let l:path = substitute(l:path, expand("%:e"), "json", "")` and adds `_noGit_` for the `.gitignore`
4. Exit vim
5. `vim filepy.py`
6. `:call SourceCodePaintersFromJSON()` loads `filepy.py__noGit_vim-codePainters.json` 

```vim
" Source marks from JSON
nmap <leader>mmso :call SourceCodePaintersFromJSON()<CR>

" Save marks to JSON
nmap <leader>mmsa :call SaveCodePaintersToJSON()<CR>

function! SetCodePaintersFile()
  " Check if g:codepaints_file_default_suffix is defined, and set a default if not
  if !exists('g:codepaints_file_default_suffix')
    let g:codepaints_file_default_suffix = '__noGit_vim-codePainters.json'
  endif

  " Full path
  " Keep file extension, to prevent overwriting codePainters-associated files with the same name. E.g. of main.js and main.html
  " Not valid cause 'PainterSaveMarks' rewrites the first ext to 'json' 
  " even if e.g. ext is in part of the file name
  " e.g. file_py.py is renamed to file_json.py
  " See codepainter#LoadMarks(...) and codepainter#SaveMarks(...) in
  " autoload/codepainter.vim
  " Yes valid since current PR !!!!!!!!!!!!
  let l:current_file = expand('%:p')

  " Add suffix
  let l:codepaints_file = l:current_file . g:codepaints_file_default_suffix

  " Return the code_painter file path
  return l:codepaints_file
endfunction

function! SaveCodePaintersToJSON()
  " Call SetCodePaintersFile to set up the bookmark file path
  let l:codepaints_file = SetCodePaintersFile()

  " Check if file already exists
  if filereadable(l:codepaints_file)
    let l:choice = input('Overwrite ' . l:codepaints_file . '? (y/n): ')
    if l:choice !~? '^y'
      echo 'CodePaints save cancelled'
      return
    endif
  endif

  execute 'PainterSaveMarks ' . l:codepaints_file
  echo 'Code paints saved to ' . l:codepaints_file
endfunction

function! SourceCodePaintersFromJSON()
  " Call SetCodePaintersFile to set up the bookmark file path
  let l:codepaints_file = SetCodePaintersFile()

  if !filereadable(l:codepaints_file)
    echo 'Code paints file not found: ' . l:codepaints_file
    return
  endif

  execute 'PainterLoadMarks ' . l:codepaints_file
  echo 'Code paints sourced from ' . l:codepaints_file
endfunction
```